### PR TITLE
bug fix in func match_nagrams

### DIFF
--- a/ngrammatcher/ngrammatcher.py
+++ b/ngrammatcher/ngrammatcher.py
@@ -317,6 +317,8 @@ class NGramMatcher():
                 if self.end_boundary_tag in head:
                     ngram = (head[self.end_boundary_tag], start_pos, end_pos)
                     not_end = None
+                elif not_end:
+                    pass
                 else:
                     not_end = i
                 i += 1

--- a/ngrammatcher/ngrammatcher.py
+++ b/ngrammatcher/ngrammatcher.py
@@ -298,6 +298,7 @@ class NGramMatcher():
 
         start_pos = None
         end_pos = None
+        not_end = None
         ngram = None
         head = self.trie
 
@@ -315,6 +316,9 @@ class NGramMatcher():
 
                 if self.end_boundary_tag in head:
                     ngram = (head[self.end_boundary_tag], start_pos, end_pos)
+                    not_end = None
+                else:
+                    not_end = i
                 i += 1
 
             # 2. word is not in subtrie
@@ -324,9 +328,13 @@ class NGramMatcher():
                 if ngram is not None:
                     ngrams.append(ngram)
                     ngram = None
-                    i = end_pos
+                    if not_end:
+                        i = not_end
+                    else:
+                        i = end_pos
                     start_pos = None
                     end_pos = None
+                    not_end = None
 
                 # no ngram found
                 else:


### PR DESCRIPTION
I found a bug in function match_ngrams.

Let me give you an example, 

```
# init NgramMatcher object
ngm = NGramMatcher()

# add ngrams and their corresponding data
ngm.insert_ngram(['the'], 'The')
ngm.insert_ngram(['the','lego','movie'], 'The Lego Movie')
ngm.insert_ngram(['lego','bricks'], 'Lego Bricks')
ngm.insert_ngram(['bricks'], 'Bricks')

# match ngrams
ngm.match_ngrams(['I', 'bought', 'the', 'lego', 'bricks'])
```

It should return `['The', 'Lego Bricks']` but its result is `['The', 'Bricks']`.
It's because it doesn't store any index values of ongoing subtries unless it has end_boundary_tag.
From above example,
when i=2, word=the, start_pos=2, end_pos=3, ngram=(The, 2, 3)
when i=3, word=lego, start_pos=2, end_pos=4, ngram=(The, 2, 3)
when i=4, word=bricks, start_pos=2, end_pos=4, ngram=None, ngrams=[(The, 2, 3)] and then i=end_pos=4
so it restarts at i=4, word=bricks skipping i=3, word=lego.

I added a new variable `not_end = None` to fix this.
If a word is in subtrie but does not have end_boundary_tag, it stores the word's index.